### PR TITLE
Add Pair Communicator prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,201 @@
+# Pair Communicator — User Lifecycle & API Map
+
+This document describes the end‑to‑end experience of a **pair‑only** children’s communicator with optional supervisors (parents/guardians). It is written in plain English and annotated with the exact API calls your server receives along the way. It finishes with endpoint catalogs for the server and clients.
+
+---
+
+## Core ideas (at a glance)
+- **Pair‑only**: exactly two devices per pair (A ↔ B).
+- **E2E encryption**: one ciphertext per message; header carries key‑wraps for recipients (peer device + any active supervisors on either side). Server never sees plaintext.
+- **Directional supervision**: each side (A or B) can have zero or more supervisors. Server enforces that new messages include required supervisor wraps for the relevant side(s).
+- **Retention**: keep ciphertext long enough for kid delivery (spool TTL, e.g., 48h). If a side has supervisors, keep up to 30 days for that side. After purge, retain signed header + hash + receipts only.
+- **Governance safety**: pairing‑mode required for add/reset; one pending governance event per side; last supervisor on a side cannot remove themselves.
+
+---
+
+## 1) Unbox & turn on (first boot)
+You power up the two communicators. Each claims its side of the pair with the backend.
+
+**Server calls:**
+- Device A → `POST /activate` `{pair_id, side:"A", device_pub:{x25519, ed25519}}`
+- Device B → `POST /activate` `{pair_id, side:"B", device_pub:{…}}`
+
+**Server behavior:** binds each device to `pair_id`, issues a device API key and returns current `policy_version` (v1 = no supervisors).
+
+**Outcome:** kids can talk immediately; no supervisor required to start.
+
+---
+
+## 2) Kid sends a message (A → B)
+Kid A records and releases. The device encrypts once and addresses the ciphertext to the correct recipients.
+
+**Device behavior:**
+1) Build **signed header** with recipient list (always includes **Device B**, plus any required supervisors per policy) and a single **ciphertext** (E2E).
+2) Send to server.
+
+**Server calls:**
+- Device A → `POST /messages` `{pair_id, from:"dev_A", to:"dev_B", policy_version, header, ciphertext}`
+- On `409 POLICY_STALE`: Device A → `GET /policy` then retries `POST /messages`.
+- Recipients poll: `GET /inbox?recipient_id=…`
+- Recipient fetches: `GET /messages/{msg_id}?recipient_id=…`
+- Recipient acknowledges: `POST /acks` `{recipient_id, msg_id, state:"delivered"}`
+
+**Server behavior:** verifies A↔B membership, checks `policy_version`, ensures all **required recipients** are present. Queues the message for Device B and any active supervisors.
+
+**Outcome:** B receives and plays; server retains according to spool/30‑day rules.
+
+---
+
+## 3) A parent links later (one‑time)
+A parent wants a feed of **future** messages involving their kid. They put the kid’s device in pairing mode and add themselves.
+
+**Steps:**
+1) Parent presses the pairing‑mode button on Device A.
+2) Device A requests a pairing token.
+3) Parent app (via BLE/QR to the device) asks the device to add them as a supervisor.
+4) Depending on policy (first supervisor or not), the add either auto‑approves or awaits same‑side approval; the other side can optionally fast‑approve.
+
+**Server calls:**
+- Device A → `POST /pairing/start` `{side:"A"}` → returns `{pairing_token}` (5‑min TTL)
+- Device A → `POST /supervisors/add` `{pair_id, side:"A", pairing_token, supervisor:{account_id, keys:{x25519_pub, ed25519_pub}}}`
+- If A already has supervisors: an A‑side supervisor approves → `POST /supervisors/approve` with Ed25519‑signed challenge
+- Optional acceleration by B‑side → `POST /supervisors/fast_approve` `{pending_id}`
+- Devices update policy on next send (or immediately after a `409 POLICY_STALE`) via `GET /policy`
+
+**Outcome:** from this point forward, **every message that involves Kid A** includes the parent’s key (so the parent can fetch/decrypt within 30 days). Kid delivery is never gated on parent presence.
+
+---
+
+## 4) Removing a supervisor (same side)
+Any A‑side supervisor can schedule removal of one or more A‑side supervisors.
+
+**Server calls:**
+- Supervisor → `POST /supervisors/remove` `{pair_id, side:"A", targets:[…]}` (24‑hour pending window)
+- Server notifies targets and B‑side supervisors.
+- At cutoff: policy updates (keys removed), `policy_version++`.
+
+**Rules:**
+- The **last remaining** A‑side supervisor **cannot remove themselves** (`403 LAST_SUPERVISOR`).
+- During the pending window, devices still wrap to the soon‑to‑be‑removed key; **after cutoff**, that supervisor’s **fetch** is blocked (authorization decided at fetch‑time).
+
+**Outcome:** governance with notice; predictable effect time.
+
+---
+
+## 5) Supervisor reset (recovery when approvers are unreachable)
+If A‑side supervisors are unreachable (lost phones, etc.), the device can request a reset.
+
+**Server calls:**
+- Device A → `POST /pairing/start` `{side:"A"}` → `{pairing_token}`
+- Device A → `POST /supervisors/reset` `{pair_id, side:"A", pairing_token}` (starts 24‑hour countdown)
+- Any active A‑side supervisor can veto → `POST /supervisors/veto` `{pending_id}`
+
+**Outcome:** if not vetoed, A‑side supervisor list is cleared at `effective_at`. The next add on A will auto‑approve (with pairing mode).
+
+---
+
+## 6) Day‑to‑day delivery & clean‑up
+- Devices and supervisors poll `GET /inbox`, fetch `GET /messages/{id}`, then `POST /acks`.
+- **Retention:**
+  - **Kid spool TTL** (e.g., 48h): keeps blobs around long enough for child delivery regardless of supervisors.
+  - **30‑day window** for any side that **has supervisors**. A side with **no supervisors** contributes **no** 30‑day hold.
+  - After purge: only **signed header**, **SHA‑256(ciphertext)**, and **receipts** remain (fetch returns 404).
+- **Ops visibility:**
+  - `GET /audit?pair_id=…` → who added/removed/reset, by whom, when, how.
+  - `GET /receipts?recipient_id=…` → delivered/acked history for devices/supervisors.
+
+**Outcome:** predictable storage, clear paper trail, strong privacy (server never has plaintext).
+
+---
+
+## Server endpoint catalog
+**Health & boot**
+- `GET /health`
+- `POST /activate`
+- `POST /pairing/start`
+
+**Governance**
+- `POST /supervisors/add`
+- `POST /supervisors/approve`
+- `POST /supervisors/fast_approve`
+- `POST /supervisors/remove`
+- `POST /supervisors/reset`
+- `POST /supervisors/veto`
+- `GET  /policy`
+
+**Messaging**
+- `POST /messages`
+- `GET  /inbox`
+- `GET  /messages/{msg_id}`
+- `POST /acks`
+
+**Ops & visibility**
+- `GET  /audit`
+- `GET  /receipts`
+
+**Common error signals**
+- `409 POLICY_STALE` (client must `GET /policy` and retry)
+- `409 PENDING_EXISTS` (one governance event per side at a time)
+- `422 INVALID_RECIPIENTS` (missing required key‑wraps)
+- `403 LAST_SUPERVISOR` (can’t remove the last remaining on that side)
+- `401/403/404/429` as usual
+
+---
+
+## Client call maps
+**Device (A or B)**
+- Bootstrapping: `POST /activate`, `GET /policy`
+- Pairing mode: `POST /pairing/start`
+- Governance initiation: `POST /supervisors/add`, `POST /supervisors/reset`
+- Messaging: `POST /messages`, `GET /inbox`, `GET /messages/{id}`, `POST /acks`
+- Policy refresh on `409 POLICY_STALE`: `GET /policy`
+
+**Supervisor app**
+- Governance: `POST /supervisors/approve`, `POST /supervisors/fast_approve`, `POST /supervisors/remove`, `POST /supervisors/veto`, `GET /policy`
+- Inbox: `GET /inbox`, `GET /messages/{id}`, `POST /acks`
+- Visibility: `GET /audit`, `GET /receipts`
+
+---
+
+## Notes for the prototype
+- Keep auth simple for week‑1: per‑device API key and supervisor bearer token; swap to mTLS + account tokens later.
+- Sign headers (Ed25519) and do E2E content with per‑message ephemeral X25519 → HKDF → AEAD. The server checks header presence/versions only.
+- Enforce **fetch‑time authorization** strictly so governance effects apply retroactively to unfetched items.
+
+
+## Local prototype
+
+### Prerequisites
+- Go 1.22+
+- Python 3.10+
+- Streamlit >= 1.32 (`pip install -r apps/requirements.txt`)
+
+### Run the stack (three terminals)
+1. **Server**
+   ```bash
+   export PC_DB_PATH="$(pwd)/paircomm.db"
+   export PC_SPOOL_TTL=172800
+   export PC_SUPERVISOR_WINDOW=2592000
+   export PC_PENDING_WINDOW=86400
+   cd server
+   go run ./cmd/server
+   ```
+2. **Kid app (port 8501)**
+   ```bash
+   cd apps
+   streamlit run kid_app.py --server.port 8501
+   ```
+3. **Parent app (port 8502)**
+   ```bash
+   cd apps
+   streamlit run parent_app.py --server.port 8502
+   ```
+
+Environment variables are optional; defaults are applied if unset. Set `PC_HTTP_ADDR` to change the server bind address (defaults to `:8080`). Set `PC_SERVER_URL` for the Streamlit apps when the server is not on `http://localhost:8080`.
+
+### Smoke test
+Run the automated end-to-end flow:
+```bash
+bash scripts/smoke.sh
+```
+The smoke script binds the API server to `127.0.0.1:18080` by default; override via `PC_SMOKE_PORT`.

--- a/apps/kid_app.py
+++ b/apps/kid_app.py
@@ -1,0 +1,169 @@
+import json
+import os
+from datetime import datetime
+
+import requests
+import streamlit as st
+
+st.set_page_config(page_title="Pair Communicator – Kid", layout="wide")
+
+SERVER_URL = os.getenv("PC_SERVER_URL", "http://localhost:8080")
+
+if "device" not in st.session_state:
+    st.session_state.device = {}
+if "policy" not in st.session_state:
+    st.session_state.policy = None
+if "inbox" not in st.session_state:
+    st.session_state.inbox = []
+
+
+def auth_headers() -> dict:
+    device = st.session_state.device
+    if not device:
+        return {}
+    return {
+        "X-Device-ID": device.get("device_id", ""),
+        "X-Device-Key": device.get("api_key", ""),
+    }
+
+
+def request_json(method: str, path: str, **kwargs):
+    url = f"{SERVER_URL}{path}"
+    try:
+        resp = requests.request(method, url, timeout=10, **kwargs)
+    except requests.RequestException as exc:
+        st.error(f"Request failed: {exc}")
+        return None
+    if resp.status_code >= 400:
+        try:
+            payload = resp.json()
+        except ValueError:
+            payload = resp.text
+        st.error(f"{resp.status_code}: {payload}")
+        return None
+    if resp.content:
+        try:
+            return resp.json()
+        except ValueError:
+            return resp.text
+    return None
+
+
+st.title("Kid Communicator")
+st.caption("Activate your device, send messages, and monitor supervisors.")
+
+with st.expander("Server settings", expanded=False):
+    st.write(f"Server URL: {SERVER_URL}")
+
+st.header("Activation")
+with st.form("activate"):
+    pair_id = st.text_input("Pair ID", value=st.session_state.device.get("pair_id", ""))
+    side = st.selectbox("Side", options=["A", "B"], index=0 if st.session_state.device.get("side", "A") == "A" else 1)
+    submitted = st.form_submit_button("Activate")
+    if submitted:
+        payload = {"pair_id": pair_id.strip(), "side": side, "device_pub": {"x25519": "placeholder"}}
+        data = request_json("POST", "/activate", json=payload)
+        if data:
+            st.session_state.device = data
+            st.session_state.device["pair_id"] = pair_id.strip()
+            st.session_state.device["side"] = side
+            st.success("Device activated")
+
+if st.session_state.device:
+    device = st.session_state.device
+    st.write("### Device credentials")
+    st.code(json.dumps(device, indent=2))
+
+    if st.button("Refresh policy", type="primary"):
+        policy = request_json("GET", "/policy", headers=auth_headers())
+        if policy:
+            st.session_state.policy = policy
+            st.success("Policy updated")
+
+    if st.session_state.policy is None:
+        st.info("Fetch policy to continue.")
+    else:
+        policy = st.session_state.policy
+        st.subheader("Pair status")
+        st.json(policy)
+
+        st.subheader("Pairing mode")
+        with st.form("pairing"):
+            submitted_pairing = st.form_submit_button("Request pairing token")
+            if submitted_pairing:
+                body = {"side": device.get("side")}
+                token_info = request_json("POST", "/pairing/start", headers=auth_headers(), json=body)
+                if token_info:
+                    st.session_state.pairing_token = token_info
+                    st.success(f"Token: {token_info['pairing_token']}")
+        if token := st.session_state.get("pairing_token"):
+            st.write(token)
+
+        st.subheader("Compose message")
+        with st.form("compose"):
+            plaintext = st.text_area("Message", placeholder="Write something secure...")
+            header = st.text_area("Header (JSON)", value=json.dumps({"note": "demo header", "ts": datetime.utcnow().isoformat()}, indent=2))
+            submitted_send = st.form_submit_button("Send message")
+            if submitted_send:
+                devices = policy.get("devices", {})
+                side = device.get("side")
+                peer_side = "B" if side == "A" else "A"
+                peer_id = devices.get(peer_side)
+                if not peer_id:
+                    st.error("Peer device not registered")
+                else:
+                    required = [peer_id]
+                    supervisors = policy.get("supervisors", {})
+                    for s_side in (side, peer_side):
+                        for sup in supervisors.get(s_side, []):
+                            if sup.get("status") == "active":
+                                required.append(sup.get("id"))
+                    payload = {
+                        "pair_id": device.get("pair_id"),
+                        "to": peer_id,
+                        "recipients": required,
+                        "header": header,
+                        "ciphertext": plaintext,
+                        "policy_version": policy.get("policy_version"),
+                    }
+                    resp = request_json("POST", "/messages/", headers=auth_headers(), json=payload)
+                    if resp:
+                        st.success(f"Message sent: {resp['message_id']}")
+
+        st.subheader("Inbox")
+        if st.button("Load inbox"):
+            inbox = request_json("GET", "/inbox", headers=auth_headers())
+            if inbox:
+                st.session_state.inbox = inbox.get("items", [])
+        inbox_items = st.session_state.get("inbox", [])
+        if inbox_items:
+            for item in inbox_items:
+                cols = st.columns([3, 2, 2, 2])
+                cols[0].write(item["message_id"])
+                cols[1].write(item.get("created_at"))
+                cols[2].write(item.get("ack_state"))
+                if cols[3].button("Open", key=f"open_{item['message_id']}"):
+                    msg = request_json("GET", f"/messages/{item['message_id']}", headers=auth_headers())
+                    if msg:
+                        st.write(msg)
+                        ack_payload = {"message_id": item["message_id"], "state": "delivered"}
+                        ack_resp = request_json("POST", "/acks", headers=auth_headers(), json=ack_payload)
+                        if ack_resp:
+                            st.success("Acknowledged")
+        else:
+            st.info("Inbox empty")
+
+        st.subheader("Receipts")
+        if st.button("Refresh receipts"):
+            receipts = request_json("GET", "/receipts", headers=auth_headers())
+            if receipts:
+                st.write(receipts)
+
+        st.subheader("Audit log")
+        if st.button("View audit log"):
+            audit = request_json("GET", "/audit", headers=auth_headers())
+            if audit:
+                st.write(audit)
+else:
+    st.info("Activate the device to begin.")
+

--- a/apps/parent_app.py
+++ b/apps/parent_app.py
@@ -1,0 +1,188 @@
+import json
+import os
+from datetime import datetime
+from typing import List
+
+import requests
+import streamlit as st
+
+st.set_page_config(page_title="Pair Communicator – Parent", layout="wide")
+
+SERVER_URL = os.getenv("PC_SERVER_URL", "http://localhost:8080")
+
+if "supervisor" not in st.session_state:
+    st.session_state.supervisor = {}
+if "policy" not in st.session_state:
+    st.session_state.policy = None
+if "inbox" not in st.session_state:
+    st.session_state.inbox = []
+
+
+def auth_headers() -> dict:
+    sup = st.session_state.supervisor
+    if not sup:
+        return {}
+    return {
+        "X-Supervisor-ID": sup.get("supervisor_id", ""),
+        "X-Supervisor-Key": sup.get("api_key", ""),
+    }
+
+
+def request_json(method: str, path: str, **kwargs):
+    url = f"{SERVER_URL}{path}"
+    try:
+        resp = requests.request(method, url, timeout=10, **kwargs)
+    except requests.RequestException as exc:
+        st.error(f"Request failed: {exc}")
+        return None
+    if resp.status_code >= 400:
+        try:
+            payload = resp.json()
+        except ValueError:
+            payload = resp.text
+        st.error(f"{resp.status_code}: {payload}")
+        return None
+    if resp.content:
+        try:
+            return resp.json()
+        except ValueError:
+            return resp.text
+    return None
+
+
+st.title("Parent Supervisor Console")
+st.caption("Link to your child, review inbox, and manage governance")
+
+with st.expander("Server settings", expanded=False):
+    st.write(f"Server URL: {SERVER_URL}")
+
+st.header("Link to communicator")
+with st.form("link"):
+    pair_id = st.text_input("Pair ID", value=st.session_state.supervisor.get("pair_id", ""))
+    side = st.selectbox("Kid side", options=["A", "B"], index=0 if st.session_state.supervisor.get("side", "A") == "A" else 1)
+    token = st.text_input("Pairing token")
+    display_name = st.text_input("Display name", value=st.session_state.supervisor.get("display_name", "Guardian"))
+    submitted = st.form_submit_button("Link")
+    if submitted:
+        payload = {
+            "pair_id": pair_id.strip(),
+            "side": side,
+            "pairing_token": token.strip(),
+            "supervisor": {"display_name": display_name},
+        }
+        data = request_json("POST", "/supervisors/add", json=payload)
+        if data:
+            st.session_state.supervisor.update(data)
+            st.session_state.supervisor["pair_id"] = pair_id.strip()
+            st.session_state.supervisor["side"] = side
+            st.session_state.supervisor["display_name"] = display_name
+            if data.get("status") == "active":
+                st.success("Supervisor activated")
+            else:
+                st.warning("Supervisor pending approval")
+
+if st.session_state.supervisor:
+    sup = st.session_state.supervisor
+    st.subheader("Supervisor credentials")
+    st.code(json.dumps(sup, indent=2))
+
+    if st.button("Refresh policy", type="primary"):
+        policy = request_json("GET", "/policy", headers=auth_headers())
+        if policy:
+            st.session_state.policy = policy
+            st.success("Policy refreshed")
+
+    if st.session_state.policy:
+        policy = st.session_state.policy
+        st.subheader("Current policy")
+        st.json(policy)
+
+        st.subheader("Inbox")
+        if st.button("Load inbox"):
+            inbox = request_json("GET", "/inbox", headers=auth_headers())
+            if inbox:
+                st.session_state.inbox = inbox.get("items", [])
+        inbox_items = st.session_state.get("inbox", [])
+        if inbox_items:
+            for item in inbox_items:
+                cols = st.columns([3, 2, 2, 2])
+                cols[0].write(item["message_id"])
+                cols[1].write(item.get("created_at"))
+                cols[2].write(item.get("ack_state"))
+                if cols[3].button("Open", key=f"p_open_{item['message_id']}"):
+                    msg = request_json("GET", f"/messages/{item['message_id']}", headers=auth_headers())
+                    if msg:
+                        st.write(msg)
+                        ack_payload = {"message_id": item["message_id"], "state": "delivered"}
+                        ack_resp = request_json("POST", "/acks", headers=auth_headers(), json=ack_payload)
+                        if ack_resp:
+                            st.success("Acknowledged")
+        else:
+            st.info("No pending messages")
+
+        st.subheader("Governance")
+        pending = policy.get("pending_events", [])
+        if pending:
+            st.write("Pending events:")
+            for event in pending:
+                cols = st.columns([3, 2, 2, 2])
+                cols[0].write(event["id"])
+                cols[1].write(f"{event['type']} ({event['side']})")
+                cols[2].write(event.get("status"))
+                cols[3].write(event.get("effective_at"))
+        else:
+            st.info("No pending governance events")
+
+        with st.form("approve"):
+            pending_id = st.text_input("Pending ID to approve")
+            approve_side = st.radio("Approval type", options=["same_side", "fast"], index=0)
+            submitted_approve = st.form_submit_button("Submit approval")
+            if submitted_approve and pending_id:
+                path = "/supervisors/approve" if approve_side == "same_side" else "/supervisors/fast_approve"
+                payload = {"pair_id": sup.get("pair_id"), "pending_id": pending_id.strip()}
+                result = request_json("POST", path, headers=auth_headers(), json=payload)
+                if result:
+                    st.success(result)
+
+        with st.form("remove"):
+            targets_raw = st.text_input("Supervisor IDs to remove (comma separated)")
+            submitted_remove = st.form_submit_button("Schedule removal")
+            if submitted_remove and targets_raw:
+                targets: List[str] = [t.strip() for t in targets_raw.split(",") if t.strip()]
+                payload = {"pair_id": sup.get("pair_id"), "side": sup.get("side"), "targets": targets}
+                result = request_json("POST", "/supervisors/remove", headers=auth_headers(), json=payload)
+                if result:
+                    st.success(result)
+
+        with st.form("reset"):
+            pairing_token = st.text_input("Pairing token for reset")
+            submitted_reset = st.form_submit_button("Schedule reset")
+            if submitted_reset and pairing_token:
+                payload = {"pair_id": sup.get("pair_id"), "side": sup.get("side"), "pairing_token": pairing_token.strip()}
+                result = request_json("POST", "/supervisors/reset", headers=auth_headers(), json=payload)
+                if result:
+                    st.warning(result)
+
+        with st.form("veto"):
+            veto_id = st.text_input("Pending ID to veto")
+            submitted_veto = st.form_submit_button("Veto reset")
+            if submitted_veto and veto_id:
+                payload = {"pair_id": sup.get("pair_id"), "pending_id": veto_id.strip()}
+                result = request_json("POST", "/supervisors/veto", headers=auth_headers(), json=payload)
+                if result:
+                    st.success(result)
+
+        st.subheader("Receipts")
+        if st.button("Refresh receipts"):
+            receipts = request_json("GET", "/receipts", headers=auth_headers())
+            if receipts:
+                st.write(receipts)
+
+        st.subheader("Audit log")
+        if st.button("View audit log"):
+            audit = request_json("GET", "/audit", headers=auth_headers())
+            if audit:
+                st.write(audit)
+else:
+    st.info("Use a pairing token to link as a supervisor.")
+

--- a/apps/requirements.txt
+++ b/apps/requirements.txt
@@ -1,0 +1,2 @@
+streamlit>=1.32
+requests>=2.31

--- a/postman_collection.json
+++ b/postman_collection.json
@@ -1,0 +1,76 @@
+{
+  "info": {
+    "name": "Pair Communicator Prototype",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Health",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/health",
+          "host": ["{{base_url}}"],
+          "path": ["health"]
+        }
+      }
+    },
+    {
+      "name": "Activate",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Content-Type", "value": "application/json"}
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"pair_id\": \"demo\",\n  \"side\": \"A\",\n  \"device_pub\": {\n    \"x25519\": \"placeholder\"\n  }\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/activate",
+          "host": ["{{base_url}}"],
+          "path": ["activate"]
+        }
+      }
+    },
+    {
+      "name": "Policy",
+      "request": {
+        "method": "GET",
+        "header": [
+          {"key": "X-Device-ID", "value": "{{device_id}}"},
+          {"key": "X-Device-Key", "value": "{{device_key}}"}
+        ],
+        "url": {
+          "raw": "{{base_url}}/policy",
+          "host": ["{{base_url}}"],
+          "path": ["policy"]
+        }
+      }
+    },
+    {
+      "name": "Post Message",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Content-Type", "value": "application/json"},
+          {"key": "X-Device-ID", "value": "{{device_id}}"},
+          {"key": "X-Device-Key", "value": "{{device_key}}"}
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"pair_id\": \"demo\",\n  \"to\": \"{{peer_device_id}}\",\n  \"recipients\": [\"{{peer_device_id}}\"],\n  \"header\": \"demo\",\n  \"ciphertext\": \"hello\",\n  \"policy_version\": {{policy_version}}\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/messages/",
+          "host": ["{{base_url}}"],
+          "path": ["messages", ""]
+        }
+      }
+    }
+  ],
+  "variable": [
+    {"key": "base_url", "value": "http://localhost:8080"}
+  ]
+}

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DB_PATH="$(mktemp)"
+export PC_DB_PATH="$DB_PATH"
+export PC_SPOOL_TTL=5
+export PC_SUPERVISOR_WINDOW=8
+export PC_PENDING_WINDOW=5
+
+PORT=${PC_SMOKE_PORT:-18080}
+export PC_HTTP_ADDR="127.0.0.1:${PORT}"
+
+if [[ "$PC_HTTP_ADDR" == :* ]]; then
+  SERVER_URL="http://127.0.0.1${PC_HTTP_ADDR}"
+else
+  SERVER_URL="http://${PC_HTTP_ADDR}"
+fi
+
+pkill -f cmd/server >/dev/null 2>&1 || true
+rm -f $ROOT_DIR/server.pid >/dev/null 2>&1 || true
+
+echo "Starting server..."
+(
+  cd "$ROOT_DIR/server"
+  go run ./cmd/server &
+  echo $! > "$ROOT_DIR/server.pid"
+)
+SERVER_PID="$(cat "$ROOT_DIR/server.pid")"
+trap 'kill "$SERVER_PID" 2>/dev/null || true; rm -f "$ROOT_DIR/server.pid" "$DB_PATH"' EXIT
+
+sleep 3
+
+echo "Activating devices A and B"
+RESP_A=$(curl -sS -X POST "$SERVER_URL/activate" -H 'Content-Type: application/json' -d '{"pair_id":"demo","side":"A","device_pub":{"x25519":"k"}}')
+RESP_B=$(curl -sS -X POST "$SERVER_URL/activate" -H 'Content-Type: application/json' -d '{"pair_id":"demo","side":"B","device_pub":{"x25519":"k"}}')
+
+DEVICE_A_ID=$(python -c 'import json,sys; print(json.loads(sys.stdin.read())["device_id"])' <<<"$RESP_A")
+DEVICE_A_KEY=$(python -c 'import json,sys; print(json.loads(sys.stdin.read())["api_key"])' <<<"$RESP_A")
+POLICY_VERSION=$(python -c 'import json,sys; print(json.loads(sys.stdin.read())["policy_version"])' <<<"$RESP_A")
+DEVICE_B_ID=$(python -c 'import json,sys; print(json.loads(sys.stdin.read())["device_id"])' <<<"$RESP_B")
+DEVICE_B_KEY=$(python -c 'import json,sys; print(json.loads(sys.stdin.read())["api_key"])' <<<"$RESP_B")
+
+echo "Sending initial message A -> B"
+FIRST_MSG=$(curl -sS -X POST "$SERVER_URL/messages/" \
+  -H 'Content-Type: application/json' \
+  -H "X-Device-ID: $DEVICE_A_ID" \
+  -H "X-Device-Key: $DEVICE_A_KEY" \
+  -d '{"pair_id":"demo","to":"'$DEVICE_B_ID'","recipients":["'$DEVICE_B_ID'"],"header":"demo","ciphertext":"hello","policy_version":'$POLICY_VERSION'}')
+FIRST_MSG_ID=$(python -c 'import json,sys; print(json.loads(sys.stdin.read())["message_id"])' <<<"$FIRST_MSG")
+
+echo "Device B fetching inbox"
+INBOX_B=$(curl -sS -H "X-Device-ID: $DEVICE_B_ID" -H "X-Device-Key: $DEVICE_B_KEY" "$SERVER_URL/inbox")
+python - <<'PY' <<<"$INBOX_B"
+import json,sys
+items=json.loads(sys.stdin.read())["items"]
+assert items, "Inbox empty"
+print(f"Inbox count: {len(items)}")
+PY
+
+FETCH_B=$(curl -sS -H "X-Device-ID: $DEVICE_B_ID" -H "X-Device-Key: $DEVICE_B_KEY" "$SERVER_URL/messages/$FIRST_MSG_ID")
+python - <<'PY' <<<"$FETCH_B"
+import json,sys
+msg=json.loads(sys.stdin.read())
+assert msg["ciphertext"]=="hello"
+print("Fetched message")
+PY
+
+curl -sS -X POST "$SERVER_URL/acks" -H 'Content-Type: application/json' -H "X-Device-ID: $DEVICE_B_ID" -H "X-Device-Key: $DEVICE_B_KEY" -d '{"message_id":"'$FIRST_MSG_ID'","state":"delivered"}' >/dev/null
+
+echo "Request pairing token"
+PAIR_TOKEN_RESP=$(curl -sS -X POST "$SERVER_URL/pairing/start" -H 'Content-Type: application/json' -H "X-Device-ID: $DEVICE_A_ID" -H "X-Device-Key: $DEVICE_A_KEY" -d '{"side":"A"}')
+PAIR_TOKEN=$(python -c 'import json,sys; print(json.loads(sys.stdin.read())["pairing_token"])' <<<"$PAIR_TOKEN_RESP")
+
+echo "Adding supervisor"
+SUP_RESP=$(curl -sS -X POST "$SERVER_URL/supervisors/add" -H 'Content-Type: application/json' -d '{"pair_id":"demo","side":"A","pairing_token":"'$PAIR_TOKEN'","supervisor":{"display_name":"Parent"}}')
+SUP_ID=$(python -c 'import json,sys; print(json.loads(sys.stdin.read())["supervisor_id"])' <<<"$SUP_RESP")
+SUP_KEY=$(python -c 'import json,sys; print(json.loads(sys.stdin.read())["api_key"])' <<<"$SUP_RESP")
+
+sleep 1
+POLICY=$(curl -sS -H "X-Device-ID: $DEVICE_A_ID" -H "X-Device-Key: $DEVICE_A_KEY" "$SERVER_URL/policy")
+POLICY_VERSION2=$(python -c 'import json,sys; print(json.loads(sys.stdin.read())["policy_version"])' <<<"$POLICY")
+
+echo "Sending message requiring supervisor wraps"
+SECOND_MSG=$(curl -sS -X POST "$SERVER_URL/messages/" \
+  -H 'Content-Type: application/json' \
+  -H "X-Device-ID: $DEVICE_A_ID" \
+  -H "X-Device-Key: $DEVICE_A_KEY" \
+  -d '{"pair_id":"demo","to":"'$DEVICE_B_ID'","recipients":["'$DEVICE_B_ID'","'$SUP_ID'"],"header":"demo2","ciphertext":"check","policy_version":'$POLICY_VERSION2'}')
+SECOND_MSG_ID=$(python -c 'import json,sys; print(json.loads(sys.stdin.read())["message_id"])' <<<"$SECOND_MSG")
+
+sleep 1
+SUP_INBOX=$(curl -sS -H "X-Supervisor-ID: $SUP_ID" -H "X-Supervisor-Key: $SUP_KEY" "$SERVER_URL/inbox")
+python - <<'PY' <<<"$SUP_INBOX"
+import json,sys
+items=json.loads(sys.stdin.read())["items"]
+assert items, "Supervisor inbox empty"
+print("Supervisor inbox OK")
+PY
+
+sleep 10
+echo "Checking purge behavior"
+HTTP_CODE=$(curl -s -o "$ROOT_DIR/second_msg.json" -w "%{http_code}" -H "X-Supervisor-ID: $SUP_ID" -H "X-Supervisor-Key: $SUP_KEY" "$SERVER_URL/messages/$SECOND_MSG_ID")
+if [[ "$HTTP_CODE" != "404" ]]; then
+  echo "Expected 404 after purge, got $HTTP_CODE"
+  exit 1
+fi
+
+echo "Smoke test passed"

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1,0 +1,1408 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+
+	_ "paircomm/server/internal/sqlitedrv"
+)
+
+type Server struct {
+	db               *sql.DB
+	spoolTTL         time.Duration
+	supervisorWindow time.Duration
+	pendingWindow    time.Duration
+	pairingTokenTTL  time.Duration
+}
+
+type deviceRecord struct {
+	ID     string
+	PairID string
+	Side   string
+	APIKey string
+}
+
+type supervisorRecord struct {
+	ID     string
+	PairID string
+	Side   string
+	APIKey string
+	Status string
+}
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	ctx := context.Background()
+
+	dbPath := os.Getenv("PC_DB_PATH")
+	if dbPath == "" {
+		dbPath = "paircomm.db"
+	}
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Fatalf("failed to ensure db dir: %v", err)
+	}
+
+	db, err := sql.Open("custom_sqlite", dbPath)
+	if err != nil {
+		log.Fatalf("open db: %v", err)
+	}
+	if err := db.PingContext(ctx); err != nil {
+		log.Fatalf("ping db: %v", err)
+	}
+
+	server := &Server{
+		db:               db,
+		spoolTTL:         getEnvDuration("PC_SPOOL_TTL", 48*time.Hour),
+		supervisorWindow: getEnvDuration("PC_SUPERVISOR_WINDOW", 30*24*time.Hour),
+		pendingWindow:    getEnvDuration("PC_PENDING_WINDOW", 24*time.Hour),
+		pairingTokenTTL:  5 * time.Minute,
+	}
+
+	if err := server.runMigrations(ctx); err != nil {
+		log.Fatalf("migrate: %v", err)
+	}
+
+	go server.startPendingWorker(ctx)
+	go server.startPurgeWorker(ctx)
+
+	router := chi.NewRouter()
+	router.Use(middleware.Recoverer)
+	router.Use(server.requestLogger)
+
+	router.Get("/health", server.handleHealth)
+	router.Post("/activate", server.handleActivate)
+	router.Post("/pairing/start", server.withDeviceAuth(server.handlePairingStart))
+	router.Get("/policy", server.withAnyAuth(server.handleGetPolicy))
+	router.Get("/status", server.withAnyAuth(server.handleStatus))
+	router.Post("/supervisors/add", server.handleSupervisorAdd)
+	router.Post("/supervisors/approve", server.withSupervisorAuth(server.handleSupervisorApprove))
+	router.Post("/supervisors/fast_approve", server.withSupervisorAuth(server.handleSupervisorFastApprove))
+	router.Post("/supervisors/remove", server.withSupervisorAuth(server.handleSupervisorRemove))
+	router.Post("/supervisors/reset", server.withDeviceAuth(server.handleSupervisorReset))
+	router.Post("/supervisors/veto", server.withSupervisorAuth(server.handleSupervisorVeto))
+	router.Get("/inbox", server.withAnyAuth(server.handleInbox))
+	router.Post("/acks", server.withAnyAuth(server.handleAck))
+	router.Get("/receipts", server.withAnyAuth(server.handleReceipts))
+	router.Get("/audit", server.withAnyAuth(server.handleAudit))
+	router.Route("/messages", func(r chi.Router) {
+		r.Post("/", server.withDeviceAuth(server.handlePostMessage))
+		r.Get("/{messageID}", server.withAnyAuth(server.handleGetMessage))
+	})
+
+	addr := getEnvString("PC_HTTP_ADDR", ":8080")
+	log.Printf("server listening on %s", addr)
+	if err := http.ListenAndServe(addr, router); err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+}
+
+func getEnvDuration(key string, fallback time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return fallback
+}
+
+func getEnvString(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func (s *Server) runMigrations(ctx context.Context) error {
+	schema := []string{
+		`CREATE TABLE IF NOT EXISTS pairs (
+pair_id TEXT PRIMARY KEY,
+policy_version INTEGER NOT NULL
+);`,
+		`CREATE TABLE IF NOT EXISTS devices (
+id TEXT PRIMARY KEY,
+pair_id TEXT NOT NULL,
+side TEXT NOT NULL,
+api_key TEXT NOT NULL,
+created_at TIMESTAMP NOT NULL
+);`,
+		`CREATE TABLE IF NOT EXISTS supervisors (
+id TEXT PRIMARY KEY,
+pair_id TEXT NOT NULL,
+side TEXT NOT NULL,
+display_name TEXT,
+api_key TEXT NOT NULL,
+status TEXT NOT NULL,
+created_at TIMESTAMP NOT NULL,
+updated_at TIMESTAMP
+);`,
+		`CREATE TABLE IF NOT EXISTS pairing_tokens (
+token TEXT PRIMARY KEY,
+pair_id TEXT NOT NULL,
+side TEXT NOT NULL,
+expires_at TIMESTAMP NOT NULL
+);`,
+		`CREATE TABLE IF NOT EXISTS messages (
+id TEXT PRIMARY KEY,
+pair_id TEXT NOT NULL,
+from_device_id TEXT NOT NULL,
+header TEXT NOT NULL,
+ciphertext TEXT,
+created_at TIMESTAMP NOT NULL,
+retention_until TIMESTAMP NOT NULL,
+purged_at TIMESTAMP,
+policy_version INTEGER NOT NULL
+);`,
+		`CREATE TABLE IF NOT EXISTS message_recipients (
+message_id TEXT NOT NULL,
+recipient_id TEXT NOT NULL,
+recipient_type TEXT NOT NULL,
+side TEXT,
+required INTEGER NOT NULL,
+ack_state TEXT NOT NULL,
+acked_at TIMESTAMP,
+PRIMARY KEY (message_id, recipient_id)
+);`,
+		`CREATE TABLE IF NOT EXISTS pending_events (
+id TEXT PRIMARY KEY,
+pair_id TEXT NOT NULL,
+side TEXT NOT NULL,
+type TEXT NOT NULL,
+status TEXT NOT NULL,
+payload TEXT NOT NULL,
+created_at TIMESTAMP NOT NULL,
+effective_at TIMESTAMP NOT NULL
+);`,
+		`CREATE TABLE IF NOT EXISTS audit_log (
+id INTEGER PRIMARY KEY AUTOINCREMENT,
+pair_id TEXT NOT NULL,
+actor_type TEXT NOT NULL,
+actor_id TEXT NOT NULL,
+event_type TEXT NOT NULL,
+details TEXT,
+created_at TIMESTAMP NOT NULL
+);`,
+	}
+	for _, stmt := range schema {
+		if _, err := s.db.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+type activateRequest struct {
+	PairID    string          `json:"pair_id"`
+	Side      string          `json:"side"`
+	DevicePub json.RawMessage `json:"device_pub"`
+}
+
+func (s *Server) handleActivate(w http.ResponseWriter, r *http.Request) {
+	var req activateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	side := strings.ToUpper(strings.TrimSpace(req.Side))
+	if side != "A" && side != "B" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid side"})
+		return
+	}
+	pairID := strings.TrimSpace(req.PairID)
+	if pairID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "pair_id required"})
+		return
+	}
+
+	tx, err := s.db.BeginTx(r.Context(), nil)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "tx start failed"})
+		return
+	}
+	defer tx.Rollback()
+
+	var policyVersion int
+	err = tx.QueryRowContext(r.Context(), "SELECT policy_version FROM pairs WHERE pair_id = ?", pairID).Scan(&policyVersion)
+	if errors.Is(err, sql.ErrNoRows) {
+		policyVersion = 1
+		if _, err := tx.ExecContext(r.Context(), "INSERT INTO pairs(pair_id, policy_version) VALUES(?, ?)", pairID, policyVersion); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "create pair failed"})
+			return
+		}
+	} else if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "pair lookup failed"})
+		return
+	}
+
+	deviceID := newID()
+	apiKey := newID()
+	now := time.Now().UTC()
+	if _, err := tx.ExecContext(r.Context(), "INSERT INTO devices(id, pair_id, side, api_key, created_at) VALUES(?,?,?,?,?)", deviceID, pairID, side, apiKey, now); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "device insert failed"})
+		return
+	}
+	if err := tx.Commit(); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "commit failed"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"pair_id":        pairID,
+		"side":           side,
+		"device_id":      deviceID,
+		"api_key":        apiKey,
+		"policy_version": policyVersion,
+	})
+}
+
+func (s *Server) withDeviceAuth(next func(http.ResponseWriter, *http.Request, deviceRecord)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		device, err := s.authenticateDevice(r.Context(), r)
+		if err != nil {
+			status := http.StatusUnauthorized
+			if errors.Is(err, sql.ErrNoRows) {
+				status = http.StatusUnauthorized
+			}
+			writeJSON(w, status, map[string]string{"error": err.Error()})
+			return
+		}
+		next(w, r, device)
+	}
+}
+
+func (s *Server) withSupervisorAuth(next func(http.ResponseWriter, *http.Request, supervisorRecord)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sup, err := s.authenticateSupervisor(r.Context(), r)
+		if err != nil {
+			status := http.StatusUnauthorized
+			writeJSON(w, status, map[string]string{"error": err.Error()})
+			return
+		}
+		next(w, r, sup)
+	}
+}
+
+type authContext struct {
+	device     *deviceRecord
+	supervisor *supervisorRecord
+}
+
+func (s *Server) withAnyAuth(next func(http.ResponseWriter, *http.Request, authContext)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if device, err := s.authenticateDevice(r.Context(), r); err == nil {
+			next(w, r, authContext{device: &device})
+			return
+		}
+		if sup, err := s.authenticateSupervisor(r.Context(), r); err == nil {
+			next(w, r, authContext{supervisor: &sup})
+			return
+		}
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "authorization required"})
+	}
+}
+
+func (s *Server) authenticateDevice(ctx context.Context, r *http.Request) (deviceRecord, error) {
+	id := r.Header.Get("X-Device-ID")
+	key := r.Header.Get("X-Device-Key")
+	if id == "" || key == "" {
+		return deviceRecord{}, errors.New("missing device credentials")
+	}
+	var device deviceRecord
+	err := s.db.QueryRowContext(ctx, "SELECT id, pair_id, side, api_key FROM devices WHERE id = ?", id).Scan(&device.ID, &device.PairID, &device.Side, &device.APIKey)
+	if err != nil {
+		return deviceRecord{}, err
+	}
+	if device.APIKey != key {
+		return deviceRecord{}, errors.New("invalid device key")
+	}
+	return device, nil
+}
+
+func (s *Server) authenticateSupervisor(ctx context.Context, r *http.Request) (supervisorRecord, error) {
+	id := r.Header.Get("X-Supervisor-ID")
+	key := r.Header.Get("X-Supervisor-Key")
+	if id == "" || key == "" {
+		return supervisorRecord{}, errors.New("missing supervisor credentials")
+	}
+	var sup supervisorRecord
+	err := s.db.QueryRowContext(ctx, "SELECT id, pair_id, side, api_key, status FROM supervisors WHERE id = ?", id).Scan(&sup.ID, &sup.PairID, &sup.Side, &sup.APIKey, &sup.Status)
+	if err != nil {
+		return supervisorRecord{}, err
+	}
+	if sup.APIKey != key {
+		return supervisorRecord{}, errors.New("invalid supervisor key")
+	}
+	if sup.Status != "active" {
+		return supervisorRecord{}, errors.New("supervisor inactive")
+	}
+	return sup, nil
+}
+
+func (s *Server) handlePairingStart(w http.ResponseWriter, r *http.Request, device deviceRecord) {
+	var body struct {
+		Side string `json:"side"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	side := strings.ToUpper(strings.TrimSpace(body.Side))
+	if side == "" {
+		side = device.Side
+	}
+	if side != device.Side {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "side mismatch"})
+		return
+	}
+	token := newID()
+	expires := time.Now().UTC().Add(s.pairingTokenTTL)
+	_, err := s.db.ExecContext(r.Context(), "INSERT INTO pairing_tokens(token, pair_id, side, expires_at) VALUES(?,?,?,?)", token, device.PairID, side, expires)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create token"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"pairing_token": token,
+		"expires_at":    expires.Format(time.RFC3339),
+	})
+}
+
+type addSupervisorRequest struct {
+	PairID       string `json:"pair_id"`
+	Side         string `json:"side"`
+	PairingToken string `json:"pairing_token"`
+	Supervisor   struct {
+		DisplayName string `json:"display_name"`
+	} `json:"supervisor"`
+}
+
+func (s *Server) handleSupervisorAdd(w http.ResponseWriter, r *http.Request) {
+	var req addSupervisorRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	pairID := strings.TrimSpace(req.PairID)
+	side := strings.ToUpper(strings.TrimSpace(req.Side))
+	token := strings.TrimSpace(req.PairingToken)
+	if pairID == "" || side == "" || token == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing fields"})
+		return
+	}
+
+	tx, err := s.db.BeginTx(r.Context(), nil)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "tx failed"})
+		return
+	}
+	defer tx.Rollback()
+
+	var tokenPairID, tokenSide, expiresStr string
+	err = tx.QueryRowContext(r.Context(), "SELECT pair_id, side, expires_at FROM pairing_tokens WHERE token = ?", token).Scan(&tokenPairID, &tokenSide, &expiresStr)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid token"})
+		return
+	}
+	expires, parseErr := time.Parse(time.RFC3339Nano, expiresStr)
+	if parseErr != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "token parse failed"})
+		return
+	}
+	if tokenPairID != pairID || tokenSide != side {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "token mismatch"})
+		return
+	}
+	if time.Now().UTC().After(expires) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "token expired"})
+		return
+	}
+
+	var policyVersion int
+	err = tx.QueryRowContext(r.Context(), "SELECT policy_version FROM pairs WHERE pair_id = ?", pairID).Scan(&policyVersion)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "pair not found"})
+		return
+	}
+
+	countActive, err := countActiveSupervisorsTx(r.Context(), tx, pairID, side)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "count supervisors failed"})
+		return
+	}
+
+	supervisorID := newID()
+	apiKey := newID()
+	now := time.Now().UTC()
+
+	if countActive == 0 {
+		if _, err := tx.ExecContext(r.Context(), "INSERT INTO supervisors(id, pair_id, side, display_name, api_key, status, created_at, updated_at) VALUES(?,?,?,?,?,?,?,?)",
+			supervisorID, pairID, side, req.Supervisor.DisplayName, apiKey, "active", now, now); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "supervisor insert failed"})
+			return
+		}
+		if _, err := tx.ExecContext(r.Context(), "UPDATE pairs SET policy_version = policy_version + 1 WHERE pair_id = ?", pairID); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "policy bump failed"})
+			return
+		}
+		if _, err := tx.ExecContext(r.Context(), "INSERT INTO audit_log(pair_id, actor_type, actor_id, event_type, details, created_at) VALUES(?,?,?,?,?,?)",
+			pairID, "system", "system", "supervisor_add", fmt.Sprintf("auto approved supervisor %s", supervisorID), now); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "audit failed"})
+			return
+		}
+		if _, err := tx.ExecContext(r.Context(), "DELETE FROM pairing_tokens WHERE token = ?", token); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "token cleanup failed"})
+			return
+		}
+		if err := tx.Commit(); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "commit failed"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":         "active",
+			"supervisor_id":  supervisorID,
+			"api_key":        apiKey,
+			"policy_version": policyVersion + 1,
+		})
+		return
+	}
+
+	pendingID := newID()
+	payload := map[string]any{
+		"supervisor_id": supervisorID,
+		"api_key":       apiKey,
+		"display_name":  req.Supervisor.DisplayName,
+	}
+	payloadBytes, _ := json.Marshal(payload)
+	effective := now.Add(s.pendingWindow)
+	if _, err := tx.ExecContext(r.Context(), "INSERT INTO supervisors(id, pair_id, side, display_name, api_key, status, created_at, updated_at) VALUES(?,?,?,?,?,?,?,?)",
+		supervisorID, pairID, side, req.Supervisor.DisplayName, apiKey, "pending", now, now); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "supervisor pending insert failed"})
+		return
+	}
+	if _, err := tx.ExecContext(r.Context(), "INSERT INTO pending_events(id, pair_id, side, type, status, payload, created_at, effective_at) VALUES(?,?,?,?,?,?,?,?)",
+		pendingID, pairID, side, "add", "pending", string(payloadBytes), now, effective); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "pending insert failed"})
+		return
+	}
+	if _, err := tx.ExecContext(r.Context(), "DELETE FROM pairing_tokens WHERE token = ?", token); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "token cleanup failed"})
+		return
+	}
+	if err := tx.Commit(); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "commit failed"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":        "pending",
+		"supervisor_id": supervisorID,
+		"api_key":       apiKey,
+		"pending_id":    pendingID,
+		"effective_at":  effective.Format(time.RFC3339),
+	})
+}
+
+func countActiveSupervisorsTx(ctx context.Context, tx *sql.Tx, pairID, side string) (int, error) {
+	var count int
+	err := tx.QueryRowContext(ctx, "SELECT COUNT(1) FROM supervisors WHERE pair_id = ? AND side = ? AND status = 'active'", pairID, side).Scan(&count)
+	return count, err
+}
+
+func (s *Server) handleSupervisorApprove(w http.ResponseWriter, r *http.Request, sup supervisorRecord) {
+	s.handleSupervisorApproval(w, r, sup, true)
+}
+
+func (s *Server) handleSupervisorFastApprove(w http.ResponseWriter, r *http.Request, sup supervisorRecord) {
+	s.handleSupervisorApproval(w, r, sup, false)
+}
+
+func (s *Server) handleSupervisorApproval(w http.ResponseWriter, r *http.Request, sup supervisorRecord, sameSide bool) {
+	var req struct {
+		PairID    string `json:"pair_id"`
+		PendingID string `json:"pending_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	pairID := strings.TrimSpace(req.PairID)
+	pendingID := strings.TrimSpace(req.PendingID)
+	if pairID == "" || pendingID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing fields"})
+		return
+	}
+	if sup.PairID != pairID {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "pair mismatch"})
+		return
+	}
+
+	var targetSide string
+	if sameSide {
+		targetSide = sup.Side
+	} else {
+		if sup.Side == "A" {
+			targetSide = "B"
+		} else {
+			targetSide = "A"
+		}
+	}
+
+	tx, err := s.db.BeginTx(r.Context(), nil)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "tx failed"})
+		return
+	}
+	defer tx.Rollback()
+
+	var side, eventType, status, payload string
+	var effective string
+	err = tx.QueryRowContext(r.Context(), "SELECT side, type, status, payload, effective_at FROM pending_events WHERE id = ? AND pair_id = ?", pendingID, pairID).Scan(&side, &eventType, &status, &payload, &effective)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "pending not found"})
+		return
+	}
+	if side != targetSide || eventType != "add" || status != "pending" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "not approvable"})
+		return
+	}
+
+	var payloadData map[string]any
+	_ = json.Unmarshal([]byte(payload), &payloadData)
+	supervisorID, _ := payloadData["supervisor_id"].(string)
+
+	now := time.Now().UTC()
+	if _, err := tx.ExecContext(r.Context(), "UPDATE supervisors SET status = 'active', updated_at = ? WHERE id = ?", now, supervisorID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "activate supervisor failed"})
+		return
+	}
+	if _, err := tx.ExecContext(r.Context(), "UPDATE pending_events SET status = 'executed', effective_at = ? WHERE id = ?", now, pendingID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "pending update failed"})
+		return
+	}
+	if _, err := tx.ExecContext(r.Context(), "UPDATE pairs SET policy_version = policy_version + 1 WHERE pair_id = ?", pairID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "policy bump failed"})
+		return
+	}
+	if _, err := tx.ExecContext(r.Context(), "INSERT INTO audit_log(pair_id, actor_type, actor_id, event_type, details, created_at) VALUES(?,?,?,?,?,?)",
+		pairID, "supervisor", sup.ID, "supervisor_approve", fmt.Sprintf("approved supervisor %s", supervisorID), now); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "audit failed"})
+		return
+	}
+	if err := tx.Commit(); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "commit failed"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "approved"})
+}
+
+func (s *Server) handleSupervisorRemove(w http.ResponseWriter, r *http.Request, sup supervisorRecord) {
+	var req struct {
+		PairID  string   `json:"pair_id"`
+		Side    string   `json:"side"`
+		Targets []string `json:"targets"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	pairID := strings.TrimSpace(req.PairID)
+	if pairID == "" || len(req.Targets) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing fields"})
+		return
+	}
+	if sup.PairID != pairID {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "pair mismatch"})
+		return
+	}
+	side := strings.ToUpper(strings.TrimSpace(req.Side))
+	if side == "" {
+		side = sup.Side
+	}
+	if side != sup.Side {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "side mismatch"})
+		return
+	}
+
+	tx, err := s.db.BeginTx(r.Context(), nil)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "tx failed"})
+		return
+	}
+	defer tx.Rollback()
+
+	countActive, err := countActiveSupervisorsTx(r.Context(), tx, pairID, side)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "count failed"})
+		return
+	}
+	removing := 0
+	isSelf := false
+	for _, id := range req.Targets {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		removing++
+		if id == sup.ID {
+			isSelf = true
+		}
+	}
+	if removing == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "no targets"})
+		return
+	}
+	if countActive-removing <= 0 && isSelf {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "last supervisor"})
+		return
+	}
+
+	payloadBytes, _ := json.Marshal(map[string]any{"targets": req.Targets})
+	effective := time.Now().UTC().Add(s.pendingWindow)
+	pendingID := newID()
+	if _, err := tx.ExecContext(r.Context(), "INSERT INTO pending_events(id, pair_id, side, type, status, payload, created_at, effective_at) VALUES(?,?,?,?,?,?,?,?)",
+		pendingID, pairID, side, "remove", "pending", string(payloadBytes), time.Now().UTC(), effective); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "pending insert failed"})
+		return
+	}
+	if _, err := tx.ExecContext(r.Context(), "INSERT INTO audit_log(pair_id, actor_type, actor_id, event_type, details, created_at) VALUES(?,?,?,?,?,?)",
+		pairID, "supervisor", sup.ID, "supervisor_remove", fmt.Sprintf("scheduled removal %s", strings.Join(req.Targets, ",")), time.Now().UTC()); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "audit failed"})
+		return
+	}
+	if err := tx.Commit(); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "commit failed"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"status": "pending", "pending_id": pendingID, "effective_at": effective.Format(time.RFC3339)})
+}
+
+func (s *Server) handleSupervisorReset(w http.ResponseWriter, r *http.Request, device deviceRecord) {
+	var req struct {
+		PairID       string `json:"pair_id"`
+		Side         string `json:"side"`
+		PairingToken string `json:"pairing_token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	pairID := strings.TrimSpace(req.PairID)
+	side := strings.ToUpper(strings.TrimSpace(req.Side))
+	if side == "" {
+		side = device.Side
+	}
+	if pairID == "" || side == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing fields"})
+		return
+	}
+	if device.PairID != pairID || device.Side != side {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "mismatch"})
+		return
+	}
+	token := strings.TrimSpace(req.PairingToken)
+	if token == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "token required"})
+		return
+	}
+
+	var tokenPairID, tokenSide, expiresStr string
+	err := s.db.QueryRowContext(r.Context(), "SELECT pair_id, side, expires_at FROM pairing_tokens WHERE token = ?", token).Scan(&tokenPairID, &tokenSide, &expiresStr)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid token"})
+		return
+	}
+	expires, parseErr := time.Parse(time.RFC3339Nano, expiresStr)
+	if parseErr != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "token parse failed"})
+		return
+	}
+	if tokenPairID != pairID || tokenSide != side || time.Now().UTC().After(expires) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "token invalid"})
+		return
+	}
+
+	effective := time.Now().UTC().Add(s.pendingWindow)
+	pendingID := newID()
+	payloadBytes, _ := json.Marshal(map[string]any{"action": "reset"})
+	_, err = s.db.ExecContext(r.Context(), "INSERT INTO pending_events(id, pair_id, side, type, status, payload, created_at, effective_at) VALUES(?,?,?,?,?,?,?,?)",
+		pendingID, pairID, side, "reset", "pending", string(payloadBytes), time.Now().UTC(), effective)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "pending insert failed"})
+		return
+	}
+	_, _ = s.db.ExecContext(r.Context(), "DELETE FROM pairing_tokens WHERE token = ?", token)
+	writeJSON(w, http.StatusOK, map[string]any{"status": "pending", "pending_id": pendingID, "effective_at": effective.Format(time.RFC3339)})
+}
+
+func (s *Server) handleSupervisorVeto(w http.ResponseWriter, r *http.Request, sup supervisorRecord) {
+	var req struct {
+		PairID    string `json:"pair_id"`
+		PendingID string `json:"pending_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	pairID := strings.TrimSpace(req.PairID)
+	pendingID := strings.TrimSpace(req.PendingID)
+	if pairID == "" || pendingID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing fields"})
+		return
+	}
+	if sup.PairID != pairID {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "pair mismatch"})
+		return
+	}
+
+	res, err := s.db.ExecContext(r.Context(), "UPDATE pending_events SET status = 'canceled' WHERE id = ? AND pair_id = ? AND status = 'pending'", pendingID, pairID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "update failed"})
+		return
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "not cancelable"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "vetoed"})
+}
+func (s *Server) handleGetPolicy(w http.ResponseWriter, r *http.Request, auth authContext) {
+	pairID := ""
+	if auth.device != nil {
+		pairID = auth.device.PairID
+	} else if auth.supervisor != nil {
+		pairID = auth.supervisor.PairID
+	}
+	if pairID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown pair"})
+		return
+	}
+
+	policy, err := s.buildPolicy(r.Context(), pairID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "policy fetch failed"})
+		return
+	}
+	writeJSON(w, http.StatusOK, policy)
+}
+
+func (s *Server) buildPolicy(ctx context.Context, pairID string) (map[string]any, error) {
+	var policyVersion int
+	if err := s.db.QueryRowContext(ctx, "SELECT policy_version FROM pairs WHERE pair_id = ?", pairID).Scan(&policyVersion); err != nil {
+		return nil, err
+	}
+
+	devices := map[string]string{}
+	rows, err := s.db.QueryContext(ctx, "SELECT id, side FROM devices WHERE pair_id = ?", pairID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, side string
+		if err := rows.Scan(&id, &side); err != nil {
+			return nil, err
+		}
+		devices[side] = id
+	}
+
+	supervisors := map[string][]map[string]any{"A": {}, "B": {}}
+	rows, err = s.db.QueryContext(ctx, "SELECT id, side, display_name, status FROM supervisors WHERE pair_id = ?", pairID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, side, displayName, status string
+		if err := rows.Scan(&id, &side, &displayName, &status); err != nil {
+			return nil, err
+		}
+		supervisors[side] = append(supervisors[side], map[string]any{
+			"id":           id,
+			"display_name": displayName,
+			"status":       status,
+		})
+	}
+
+	pending := []map[string]any{}
+	rows, err = s.db.QueryContext(ctx, "SELECT id, side, type, status, payload, effective_at FROM pending_events WHERE pair_id = ?", pairID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, side, typ, status, payload string
+		var effective string
+		if err := rows.Scan(&id, &side, &typ, &status, &payload, &effective); err != nil {
+			return nil, err
+		}
+		pending = append(pending, map[string]any{
+			"id":           id,
+			"side":         side,
+			"type":         typ,
+			"status":       status,
+			"payload":      json.RawMessage(payload),
+			"effective_at": effective,
+		})
+	}
+
+	return map[string]any{
+		"pair_id":        pairID,
+		"policy_version": policyVersion,
+		"devices":        devices,
+		"supervisors":    supervisors,
+		"pending_events": pending,
+	}, nil
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request, auth authContext) {
+	pairID := ""
+	if auth.device != nil {
+		pairID = auth.device.PairID
+	} else if auth.supervisor != nil {
+		pairID = auth.supervisor.PairID
+	}
+	if pairID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown pair"})
+		return
+	}
+	policy, err := s.buildPolicy(r.Context(), pairID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "policy fetch failed"})
+		return
+	}
+	writeJSON(w, http.StatusOK, policy)
+}
+
+type postMessageRequest struct {
+	PairID        string   `json:"pair_id"`
+	To            string   `json:"to"`
+	Recipients    []string `json:"recipients"`
+	Header        string   `json:"header"`
+	Ciphertext    string   `json:"ciphertext"`
+	PolicyVersion int      `json:"policy_version"`
+}
+
+func (s *Server) handlePostMessage(w http.ResponseWriter, r *http.Request, device deviceRecord) {
+	var req postMessageRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	if req.PairID != device.PairID {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "pair mismatch"})
+		return
+	}
+	if req.PolicyVersion == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "policy_version required"})
+		return
+	}
+
+	policy, err := s.buildPolicy(r.Context(), device.PairID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "policy fetch failed"})
+		return
+	}
+	currentVersion := policy["policy_version"].(int)
+	if req.PolicyVersion != currentVersion {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "POLICY_STALE"})
+		return
+	}
+
+	recipientSet := map[string]struct{}{}
+	for _, id := range req.Recipients {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			recipientSet[id] = struct{}{}
+		}
+	}
+	if _, ok := recipientSet[req.To]; !ok {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "INVALID_RECIPIENTS"})
+		return
+	}
+
+	devices := policy["devices"].(map[string]string)
+	peerSide := "A"
+	if device.Side == "A" {
+		peerSide = "B"
+	}
+	peerID := devices[peerSide]
+	if peerID == "" || peerID != req.To {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "INVALID_RECIPIENTS"})
+		return
+	}
+
+	requiredRecipients := []string{peerID}
+	supervisors := policy["supervisors"].(map[string][]map[string]any)
+	for _, side := range []string{device.Side, peerSide} {
+		for _, sup := range supervisors[side] {
+			if status, ok := sup["status"].(string); ok && status == "active" {
+				if id, ok := sup["id"].(string); ok {
+					requiredRecipients = append(requiredRecipients, id)
+				}
+			}
+		}
+	}
+	for _, reqID := range requiredRecipients {
+		if _, ok := recipientSet[reqID]; !ok {
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "INVALID_RECIPIENTS"})
+			return
+		}
+	}
+
+	messageID := newID()
+	now := time.Now().UTC()
+	retention := now.Add(s.spoolTTL)
+	for _, side := range []string{device.Side, peerSide} {
+		if len(activeSupervisors(supervisors[side])) > 0 {
+			candidate := now.Add(s.supervisorWindow)
+			if candidate.After(retention) {
+				retention = candidate
+			}
+		}
+	}
+
+	tx, err := s.db.BeginTx(r.Context(), nil)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "tx failed"})
+		return
+	}
+	defer tx.Rollback()
+
+	_, err = tx.ExecContext(r.Context(), "INSERT INTO messages(id, pair_id, from_device_id, header, ciphertext, created_at, retention_until, policy_version) VALUES(?,?,?,?,?,?,?,?)",
+		messageID, device.PairID, device.ID, req.Header, req.Ciphertext, now, retention, req.PolicyVersion)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "message insert failed"})
+		return
+	}
+
+	for id := range recipientSet {
+		recipientType := "device"
+		side := ""
+		if id == devices["A"] {
+			side = "A"
+		}
+		if id == devices["B"] {
+			side = "B"
+		}
+		if id != devices["A"] && id != devices["B"] {
+			recipientType = "supervisor"
+			if supSide := findSupervisorSide(supervisors, id); supSide != "" {
+				side = supSide
+			}
+		}
+		required := 0
+		for _, reqID := range requiredRecipients {
+			if reqID == id {
+				required = 1
+				break
+			}
+		}
+		_, err := tx.ExecContext(r.Context(), "INSERT INTO message_recipients(message_id, recipient_id, recipient_type, side, required, ack_state) VALUES(?,?,?,?,?,?)",
+			messageID, id, recipientType, side, required, "pending")
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "recipients insert failed"})
+			return
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "commit failed"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"message_id": messageID, "created_at": now.Format(time.RFC3339)})
+}
+
+func activeSupervisors(list []map[string]any) []map[string]any {
+	var out []map[string]any
+	for _, sup := range list {
+		if status, ok := sup["status"].(string); ok && status == "active" {
+			out = append(out, sup)
+		}
+	}
+	return out
+}
+
+func findSupervisorSide(supervisors map[string][]map[string]any, id string) string {
+	for side, list := range supervisors {
+		for _, sup := range list {
+			if supID, ok := sup["id"].(string); ok && supID == id {
+				return side
+			}
+		}
+	}
+	return ""
+}
+
+func (s *Server) handleInbox(w http.ResponseWriter, r *http.Request, auth authContext) {
+	recipientID := ""
+	typeLabel := ""
+	if auth.device != nil {
+		recipientID = auth.device.ID
+		typeLabel = "device"
+	} else if auth.supervisor != nil {
+		recipientID = auth.supervisor.ID
+		typeLabel = "supervisor"
+	}
+	if recipientID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown recipient"})
+		return
+	}
+
+	rows, err := s.db.QueryContext(r.Context(), `SELECT m.id, m.created_at, m.from_device_id, mr.ack_state
+        FROM message_recipients mr
+        JOIN messages m ON m.id = mr.message_id
+        WHERE mr.recipient_id = ?
+        ORDER BY m.created_at DESC LIMIT 50`, recipientID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "inbox fetch failed"})
+		return
+	}
+	defer rows.Close()
+
+	items := []map[string]any{}
+	for rows.Next() {
+		var id, fromDeviceID, ackState string
+		var created string
+		if err := rows.Scan(&id, &created, &fromDeviceID, &ackState); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "scan failed"})
+			return
+		}
+		items = append(items, map[string]any{
+			"message_id":  id,
+			"from_device": fromDeviceID,
+			"created_at":  created,
+			"ack_state":   ackState,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"recipient_type": typeLabel, "items": items})
+}
+
+func (s *Server) handleGetMessage(w http.ResponseWriter, r *http.Request, auth authContext) {
+	messageID := chi.URLParam(r, "messageID")
+	if strings.TrimSpace(messageID) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing id"})
+		return
+	}
+
+	recipientID := ""
+	pairID := ""
+	if auth.device != nil {
+		recipientID = auth.device.ID
+		pairID = auth.device.PairID
+	} else if auth.supervisor != nil {
+		recipientID = auth.supervisor.ID
+		pairID = auth.supervisor.PairID
+	}
+
+	var messagePairID string
+	var ciphertext sql.NullString
+	var header string
+	var created string
+	var purgedAt sql.NullString
+	err := s.db.QueryRowContext(r.Context(), `SELECT m.pair_id, m.header, m.ciphertext, m.created_at, m.purged_at
+        FROM messages m
+        JOIN message_recipients mr ON mr.message_id = m.id
+        WHERE m.id = ? AND mr.recipient_id = ?`, messageID, recipientID).Scan(&messagePairID, &header, &ciphertext, &created, &purgedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+		return
+	}
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "fetch failed"})
+		return
+	}
+	if messagePairID != pairID {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "pair mismatch"})
+		return
+	}
+	if purgedAt.Valid || !ciphertext.Valid || ciphertext.String == "" {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "message purged"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"message_id": messageID,
+		"header":     header,
+		"ciphertext": ciphertext.String,
+		"created_at": created,
+	})
+}
+
+func (s *Server) handleAck(w http.ResponseWriter, r *http.Request, auth authContext) {
+	var req struct {
+		MessageID string `json:"message_id"`
+		State     string `json:"state"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	state := strings.ToLower(strings.TrimSpace(req.State))
+	if state == "" {
+		state = "delivered"
+	}
+	if state != "delivered" && state != "read" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid state"})
+		return
+	}
+	recipientID := ""
+	if auth.device != nil {
+		recipientID = auth.device.ID
+	} else if auth.supervisor != nil {
+		recipientID = auth.supervisor.ID
+	}
+	if recipientID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown recipient"})
+		return
+	}
+
+	res, err := s.db.ExecContext(r.Context(), "UPDATE message_recipients SET ack_state = ?, acked_at = ? WHERE message_id = ? AND recipient_id = ?", state, time.Now().UTC(), req.MessageID, recipientID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "ack failed"})
+		return
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "acked"})
+}
+
+func (s *Server) handleReceipts(w http.ResponseWriter, r *http.Request, auth authContext) {
+	recipientID := ""
+	if auth.device != nil {
+		recipientID = auth.device.ID
+	} else if auth.supervisor != nil {
+		recipientID = auth.supervisor.ID
+	}
+	rows, err := s.db.QueryContext(r.Context(), `SELECT message_id, ack_state, acked_at FROM message_recipients WHERE recipient_id = ? ORDER BY acked_at DESC LIMIT 100`, recipientID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "receipts failed"})
+		return
+	}
+	defer rows.Close()
+
+	items := []map[string]any{}
+	for rows.Next() {
+		var messageID, state string
+		var ackedAt sql.NullString
+		if err := rows.Scan(&messageID, &state, &ackedAt); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "scan failed"})
+			return
+		}
+		item := map[string]any{"message_id": messageID, "state": state}
+		if ackedAt.Valid {
+			item["acked_at"] = ackedAt.String
+		}
+		items = append(items, item)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": items})
+}
+
+func (s *Server) handleAudit(w http.ResponseWriter, r *http.Request, auth authContext) {
+	pairID := ""
+	if auth.device != nil {
+		pairID = auth.device.PairID
+	} else if auth.supervisor != nil {
+		pairID = auth.supervisor.PairID
+	}
+	rows, err := s.db.QueryContext(r.Context(), `SELECT actor_type, actor_id, event_type, details, created_at FROM audit_log WHERE pair_id = ? ORDER BY created_at DESC LIMIT 100`, pairID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "audit failed"})
+		return
+	}
+	defer rows.Close()
+	items := []map[string]any{}
+	for rows.Next() {
+		var actorType, actorID, eventType, details string
+		var created string
+		if err := rows.Scan(&actorType, &actorID, &eventType, &details, &created); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "scan failed"})
+			return
+		}
+		items = append(items, map[string]any{
+			"actor_type": actorType,
+			"actor_id":   actorID,
+			"event_type": eventType,
+			"details":    details,
+			"created_at": created,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": items})
+}
+
+func (s *Server) startPendingWorker(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.processPendingEvents(ctx); err != nil {
+				log.Printf("pending worker error: %v", err)
+			}
+		}
+	}
+}
+
+func (s *Server) processPendingEvents(ctx context.Context) error {
+	now := time.Now().UTC()
+	rows, err := s.db.QueryContext(ctx, "SELECT id, pair_id, side, type, payload FROM pending_events WHERE status = 'pending' AND effective_at <= ?", now)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, pairID, side, typ, payload string
+		if err := rows.Scan(&id, &pairID, &side, &typ, &payload); err != nil {
+			return err
+		}
+		if err := s.executePendingEvent(ctx, id, pairID, side, typ, payload); err != nil {
+			log.Printf("execute pending %s failed: %v", id, err)
+		}
+	}
+	return nil
+}
+
+func (s *Server) executePendingEvent(ctx context.Context, id, pairID, side, typ, payload string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var status string
+	err = tx.QueryRowContext(ctx, "SELECT status FROM pending_events WHERE id = ?", id).Scan(&status)
+	if err != nil {
+		return err
+	}
+	if status != "pending" {
+		return tx.Commit()
+	}
+
+	now := time.Now().UTC()
+	switch typ {
+	case "add":
+		var payloadData map[string]any
+		_ = json.Unmarshal([]byte(payload), &payloadData)
+		supervisorID, _ := payloadData["supervisor_id"].(string)
+		if _, err := tx.ExecContext(ctx, "UPDATE supervisors SET status = 'active', updated_at = ? WHERE id = ?", now, supervisorID); err != nil {
+			return err
+		}
+	case "remove":
+		var payloadData struct {
+			Targets []string `json:"targets"`
+		}
+		_ = json.Unmarshal([]byte(payload), &payloadData)
+		for _, t := range payloadData.Targets {
+			if _, err := tx.ExecContext(ctx, "UPDATE supervisors SET status = 'removed', updated_at = ? WHERE id = ?", now, strings.TrimSpace(t)); err != nil {
+				return err
+			}
+		}
+	case "reset":
+		if _, err := tx.ExecContext(ctx, "UPDATE supervisors SET status = 'removed', updated_at = ? WHERE pair_id = ? AND side = ?", now, pairID, side); err != nil {
+			return err
+		}
+	default:
+		return errors.New("unknown pending type")
+	}
+
+	if _, err := tx.ExecContext(ctx, "UPDATE pairs SET policy_version = policy_version + 1 WHERE pair_id = ?", pairID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "UPDATE pending_events SET status = 'executed', effective_at = ? WHERE id = ?", now, id); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Server) startPurgeWorker(ctx context.Context) {
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.purgeExpiredMessages(ctx); err != nil {
+				log.Printf("purge worker error: %v", err)
+			}
+		}
+	}
+}
+
+func (s *Server) purgeExpiredMessages(ctx context.Context) error {
+	now := time.Now().UTC()
+	rows, err := s.db.QueryContext(ctx, "SELECT id FROM messages WHERE purged_at IS NULL AND (ciphertext IS NOT NULL AND ciphertext != '') AND retention_until <= ?", now)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return err
+		}
+		if _, err := s.db.ExecContext(ctx, "UPDATE messages SET ciphertext = '', purged_at = ? WHERE id = ?", now, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) requestLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		lrw := &loggingResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(lrw, r)
+		log.Printf("%s %s %d %v", r.Method, r.URL.Path, lrw.status, time.Since(start))
+	})
+}
+
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (l *loggingResponseWriter) WriteHeader(code int) {
+	l.status = code
+	l.ResponseWriter.WriteHeader(code)
+}
+
+func newID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(b)
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,0 +1,7 @@
+module paircomm/server
+
+go 1.22
+
+require github.com/go-chi/chi/v5 v5.0.0
+
+replace github.com/go-chi/chi/v5 => ./internal/thirdparty/chi

--- a/server/internal/sqlitedrv/sqlitedrv.go
+++ b/server/internal/sqlitedrv/sqlitedrv.go
@@ -1,0 +1,266 @@
+package sqlitedrv
+
+// #cgo CFLAGS: -DSQLITE_THREADSAFE=1
+// #cgo LDFLAGS: -lsqlite3
+// #include <sqlite3.h>
+// #include <stdlib.h>
+// static int bind_text(sqlite3_stmt* stmt, int idx, const char* value, int len) {
+//   return sqlite3_bind_text(stmt, idx, value, len, SQLITE_TRANSIENT);
+// }
+// static int bind_blob(sqlite3_stmt* stmt, int idx, const void* value, int len) {
+//   return sqlite3_bind_blob(stmt, idx, value, len, SQLITE_TRANSIENT);
+// }
+import "C"
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+	"unsafe"
+)
+
+func init() {
+	sql.Register("custom_sqlite", &Driver{})
+}
+
+type Driver struct{}
+
+type conn struct {
+	db *C.sqlite3
+}
+
+type stmt struct {
+	conn  *conn
+	query string
+}
+
+type rows struct {
+	stmt    *C.sqlite3_stmt
+	conn    *conn
+	columns []string
+	closed  bool
+}
+
+type tx struct {
+	conn *conn
+}
+
+func (d *Driver) Open(name string) (driver.Conn, error) {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	var db *C.sqlite3
+	if rc := C.sqlite3_open_v2(cname, &db, C.SQLITE_OPEN_READWRITE|C.SQLITE_OPEN_CREATE|C.SQLITE_OPEN_FULLMUTEX, nil); rc != C.SQLITE_OK {
+		msg := C.GoString(C.sqlite3_errmsg(db))
+		if db != nil {
+			C.sqlite3_close(db)
+		}
+		return nil, fmt.Errorf("sqlite open: %s", msg)
+	}
+	C.sqlite3_busy_timeout(db, 5000)
+	c := &conn{db: db}
+	if err := c.execSimple("PRAGMA foreign_keys=ON"); err != nil {
+		c.Close()
+		return nil, err
+	}
+	if err := c.execSimple("PRAGMA journal_mode=WAL"); err != nil {
+		c.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *conn) execSimple(sql string) error {
+	csql := C.CString(sql)
+	defer C.free(unsafe.Pointer(csql))
+	if rc := C.sqlite3_exec(c.db, csql, nil, nil, nil); rc != C.SQLITE_OK {
+		return errors.New(C.GoString(C.sqlite3_errmsg(c.db)))
+	}
+	return nil
+}
+
+func (c *conn) Prepare(query string) (driver.Stmt, error) {
+	return &stmt{conn: c, query: query}, nil
+}
+
+func (c *conn) Close() error {
+	if c.db != nil {
+		if rc := C.sqlite3_close(c.db); rc != C.SQLITE_OK {
+			return fmt.Errorf("sqlite close: %s", C.GoString(C.sqlite3_errmsg(c.db)))
+		}
+		c.db = nil
+	}
+	return nil
+}
+
+func (c *conn) Begin() (driver.Tx, error) {
+	if err := c.execSimple("BEGIN"); err != nil {
+		return nil, err
+	}
+	return &tx{conn: c}, nil
+}
+
+func (t *tx) Commit() error {
+	return t.conn.execSimple("COMMIT")
+}
+
+func (t *tx) Rollback() error {
+	return t.conn.execSimple("ROLLBACK")
+}
+
+func (s *stmt) Close() error {
+	return nil
+}
+
+func (s *stmt) NumInput() int {
+	return -1
+}
+
+func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
+	cstmt, err := s.prepare()
+	if err != nil {
+		return nil, err
+	}
+	defer C.sqlite3_finalize(cstmt)
+	if err := bindArgs(cstmt, args); err != nil {
+		return nil, err
+	}
+	rc := C.sqlite3_step(cstmt)
+	if rc != C.SQLITE_DONE {
+		return nil, fmt.Errorf("sqlite step: %s", C.GoString(C.sqlite3_errmsg(s.conn.db)))
+	}
+	lastID := int64(C.sqlite3_last_insert_rowid(s.conn.db))
+	affected := int64(C.sqlite3_changes(s.conn.db))
+	return &result{lastID: lastID, affected: affected}, nil
+}
+
+func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
+	cstmt, err := s.prepare()
+	if err != nil {
+		return nil, err
+	}
+	if err := bindArgs(cstmt, args); err != nil {
+		C.sqlite3_finalize(cstmt)
+		return nil, err
+	}
+	colCount := int(C.sqlite3_column_count(cstmt))
+	cols := make([]string, colCount)
+	for i := 0; i < colCount; i++ {
+		cols[i] = C.GoString(C.sqlite3_column_name(cstmt, C.int(i)))
+	}
+	return &rows{stmt: cstmt, conn: s.conn, columns: cols}, nil
+}
+
+func (s *stmt) prepare() (*C.sqlite3_stmt, error) {
+	cquery := C.CString(s.query)
+	defer C.free(unsafe.Pointer(cquery))
+	var cstmt *C.sqlite3_stmt
+	if rc := C.sqlite3_prepare_v2(s.conn.db, cquery, -1, &cstmt, nil); rc != C.SQLITE_OK {
+		return nil, fmt.Errorf("sqlite prepare: %s", C.GoString(C.sqlite3_errmsg(s.conn.db)))
+	}
+	return cstmt, nil
+}
+
+type result struct {
+	lastID   int64
+	affected int64
+}
+
+func (r *result) LastInsertId() (int64, error) { return r.lastID, nil }
+
+func (r *result) RowsAffected() (int64, error) { return r.affected, nil }
+
+func bindArgs(stmt *C.sqlite3_stmt, args []driver.Value) error {
+	for i, arg := range args {
+		idx := C.int(i + 1)
+		switch v := arg.(type) {
+		case nil:
+			C.sqlite3_bind_null(stmt, idx)
+		case int64:
+			C.sqlite3_bind_int64(stmt, idx, C.sqlite3_int64(v))
+		case float64:
+			C.sqlite3_bind_double(stmt, idx, C.double(v))
+		case bool:
+			if v {
+				C.sqlite3_bind_int(stmt, idx, 1)
+			} else {
+				C.sqlite3_bind_int(stmt, idx, 0)
+			}
+		case []byte:
+			if len(v) == 0 {
+				C.bind_blob(stmt, idx, unsafe.Pointer(nil), 0)
+			} else {
+				C.bind_blob(stmt, idx, unsafe.Pointer(&v[0]), C.int(len(v)))
+			}
+		case string:
+			cstr := C.CString(v)
+			C.bind_text(stmt, idx, cstr, C.int(len(v)))
+			C.free(unsafe.Pointer(cstr))
+		case time.Time:
+			formatted := v.UTC().Format(time.RFC3339Nano)
+			cstr := C.CString(formatted)
+			C.bind_text(stmt, idx, cstr, C.int(len(formatted)))
+			C.free(unsafe.Pointer(cstr))
+		default:
+			return fmt.Errorf("unsupported bind type %T", arg)
+		}
+	}
+	return nil
+}
+
+func (r *rows) Columns() []string {
+	return r.columns
+}
+
+func (r *rows) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	if r.stmt != nil {
+		C.sqlite3_finalize(r.stmt)
+		r.stmt = nil
+	}
+	return nil
+}
+
+func (r *rows) Next(dest []driver.Value) error {
+	rc := C.sqlite3_step(r.stmt)
+	switch rc {
+	case C.SQLITE_ROW:
+		for i := range dest {
+			typeCode := C.sqlite3_column_type(r.stmt, C.int(i))
+			switch typeCode {
+			case C.SQLITE_INTEGER:
+				dest[i] = int64(C.sqlite3_column_int64(r.stmt, C.int(i)))
+			case C.SQLITE_FLOAT:
+				dest[i] = float64(C.sqlite3_column_double(r.stmt, C.int(i)))
+			case C.SQLITE_TEXT:
+				dest[i] = C.GoString((*C.char)(unsafe.Pointer(C.sqlite3_column_text(r.stmt, C.int(i)))))
+			case C.SQLITE_BLOB:
+				sz := C.sqlite3_column_bytes(r.stmt, C.int(i))
+				if sz == 0 {
+					dest[i] = []byte{}
+				} else {
+					ptr := C.sqlite3_column_blob(r.stmt, C.int(i))
+					buf := C.GoBytes(ptr, sz)
+					dest[i] = buf
+				}
+			case C.SQLITE_NULL:
+				dest[i] = nil
+			default:
+				dest[i] = nil
+			}
+		}
+		return nil
+	case C.SQLITE_DONE:
+		r.Close()
+		return io.EOF
+	default:
+		err := fmt.Errorf("sqlite step: %s", C.GoString(C.sqlite3_errmsg(r.conn.db)))
+		r.Close()
+		return err
+	}
+}

--- a/server/internal/thirdparty/chi/go.mod
+++ b/server/internal/thirdparty/chi/go.mod
@@ -1,0 +1,3 @@
+module github.com/go-chi/chi/v5
+
+go 1.22

--- a/server/internal/thirdparty/chi/middleware/recoverer.go
+++ b/server/internal/thirdparty/chi/middleware/recoverer.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+)
+
+func Recoverer(next http.Handler) http.Handler {
+	if next == nil {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		})
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Printf("panic recovered: %v", rec)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/internal/thirdparty/chi/router.go
+++ b/server/internal/thirdparty/chi/router.go
@@ -1,0 +1,195 @@
+package chi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+type Middleware func(http.Handler) http.Handler
+
+type Router interface {
+	http.Handler
+	Use(middlewares ...Middleware)
+	Method(method, pattern string, handler http.HandlerFunc)
+	Get(pattern string, handler http.HandlerFunc)
+	Post(pattern string, handler http.HandlerFunc)
+	Route(pattern string, fn func(r Router))
+}
+
+type Mux struct {
+	base        string
+	routes      []route
+	middlewares []Middleware
+}
+
+type route struct {
+	method   string
+	segments []segment
+	handler  http.Handler
+}
+
+type segment struct {
+	literal bool
+	value   string
+}
+
+type paramsKeyType struct{}
+
+var paramsKey paramsKeyType
+
+func NewRouter() *Mux {
+	return &Mux{base: "/"}
+}
+
+func (m *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := normalizePath(r.URL.Path)
+	segments := splitPath(path)
+	for _, rt := range m.routes {
+		if rt.method != "" && r.Method != rt.method {
+			continue
+		}
+		if len(rt.segments) != len(segments) {
+			continue
+		}
+		params := map[string]string{}
+		matched := true
+		for idx, seg := range rt.segments {
+			if seg.literal {
+				if seg.value != segments[idx] {
+					matched = false
+					break
+				}
+				continue
+			}
+			params[seg.value] = segments[idx]
+		}
+		if !matched {
+			continue
+		}
+		if len(params) > 0 {
+			ctx := context.WithValue(r.Context(), paramsKey, params)
+			r = r.WithContext(ctx)
+		}
+		rt.handler.ServeHTTP(w, r)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func (m *Mux) Use(middlewares ...Middleware) {
+	m.middlewares = append(m.middlewares, middlewares...)
+}
+
+func (m *Mux) Method(method, pattern string, handler http.HandlerFunc) {
+	if handler == nil {
+		return
+	}
+	fullPath := joinPaths(m.base, pattern)
+	rt := route{
+		method:   strings.ToUpper(method),
+		segments: parsePattern(fullPath),
+		handler:  m.wrapMiddlewares(handler),
+	}
+	m.routes = append(m.routes, rt)
+}
+
+func (m *Mux) Get(pattern string, handler http.HandlerFunc) {
+	m.Method(http.MethodGet, pattern, handler)
+}
+
+func (m *Mux) Post(pattern string, handler http.HandlerFunc) {
+	m.Method(http.MethodPost, pattern, handler)
+}
+
+func (m *Mux) Route(pattern string, fn func(r Router)) {
+	if fn == nil {
+		return
+	}
+	sub := &Mux{
+		base:        joinPaths(m.base, pattern),
+		middlewares: append([]Middleware{}, m.middlewares...),
+	}
+	fn(sub)
+	m.routes = append(m.routes, sub.routes...)
+}
+
+func (m *Mux) wrapMiddlewares(handler http.HandlerFunc) http.Handler {
+	h := http.Handler(handler)
+	for i := len(m.middlewares) - 1; i >= 0; i-- {
+		h = m.middlewares[i](h)
+	}
+	return h
+}
+
+func parsePattern(pattern string) []segment {
+	normalized := normalizePath(pattern)
+	parts := splitPath(normalized)
+	if len(parts) == 0 {
+		return []segment{}
+	}
+	segments := make([]segment, 0, len(parts))
+	for _, part := range parts {
+		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
+			name := strings.TrimSuffix(strings.TrimPrefix(part, "{"), "}")
+			segments = append(segments, segment{literal: false, value: name})
+			continue
+		}
+		segments = append(segments, segment{literal: true, value: part})
+	}
+	return segments
+}
+
+func splitPath(path string) []string {
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return []string{}
+	}
+	return strings.Split(trimmed, "/")
+}
+
+func normalizePath(path string) string {
+	if path == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if len(path) > 1 && strings.HasSuffix(path, "/") {
+		path = strings.TrimSuffix(path, "/")
+	}
+	if path == "" {
+		return "/"
+	}
+	return path
+}
+
+func joinPaths(base, path string) string {
+	if base == "" {
+		base = "/"
+	}
+	if !strings.HasPrefix(base, "/") {
+		base = "/" + base
+	}
+	if path == "" || path == "/" {
+		return base
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if base == "/" {
+		return normalizePath(path)
+	}
+	combined := base + path
+	return normalizePath(combined)
+}
+
+func URLParam(r *http.Request, key string) string {
+	if r == nil {
+		return ""
+	}
+	if values, ok := r.Context().Value(paramsKey).(map[string]string); ok {
+		return values[key]
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- implement Go server with SQLite persistence, policy enforcement, governance flows, and background workers
- add custom chi-compatible router shim and CGO-backed SQLite driver to keep dependencies local
- provide Streamlit kid/parent apps, smoke test script, and updated README/postman collection for local prototyping

## Testing
- bash scripts/smoke.sh


------
https://chatgpt.com/codex/tasks/task_e_68e216732f84832f8fc475e332361b63