### PR TITLE
Log database path and query instructions on startup

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -65,6 +65,14 @@ func main() {
 		log.Fatalf("ping db: %v", err)
 	}
 
+	absDBPath, err := filepath.Abs(dbPath)
+	if err != nil {
+		log.Printf("warn: resolving absolute db path: %v", err)
+		absDBPath = dbPath
+	}
+	log.Printf("database initialized at %s", absDBPath)
+	log.Printf("to inspect the database, run: sqlite3 %q 'SELECT * FROM pairs;'", absDBPath)
+
 	server := &Server{
 		db:               db,
 		spoolTTL:         getEnvDuration("PC_SPOOL_TTL", 48*time.Hour),


### PR DESCRIPTION
## Summary
- log the absolute path to the SQLite database after it is opened
- print a sample sqlite3 command to inspect the stored data

## Testing
- go test ./... *(fails: command hung, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68e231a8f494832fbce7a2ea3d38c5b8